### PR TITLE
aa_tree back to being stable after being reworked

### DIFF
--- a/math/aa_tree.c
+++ b/math/aa_tree.c
@@ -1,141 +1,154 @@
 #include "aa_tree.h"
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 static inline
-aa_node_t * get_node(aa_node_t * node, off_t abs_off, size_t node_size) {
-  return (aa_node_t *)((unsigned char *) node + abs_off * node_size);
+aa_node_t * get_node(aa_tree_t * tree, off_t node) {
+  return (aa_node_t *)((unsigned char *) tree->node_root + node * tree->node_size);
 }
 
-unsigned int aa_error_check_helper(aa_node_t * root, off_t abs_off, off_t max_off, unsigned int node_idx, unsigned int depth, size_t node_size) {
-  if (abs_off == 0) {
-    for (unsigned int i = 0; i < depth; i++) printf("\t");
-    printf("[node %u]: NIL\n", node_idx);
-    return node_idx + 1;
-  }
-  if (abs_off < 0 || abs_off > max_off) {
-    for (unsigned int i = 0; i < depth; i++) printf("\t");
-    printf("[node %u]: off %lld out of bounds\n", node_idx, abs_off);
-    return node_idx + 1;
-  }
-  if (get_node(root, abs_off, node_size)->left == 0 && get_node(root, abs_off, node_size)->right == 0) return node_idx;
-  node_idx = aa_error_check_helper(root, abs_off + get_node(root, abs_off, node_size)->left, max_off, node_idx, depth + 1, node_size);
-  for (unsigned int i = 0; i < depth; i++) printf("\t");
-  printf("[node %u]: off %lld\n", node_idx++, abs_off);
-  node_idx = aa_error_check_helper(root, abs_off + get_node(root, abs_off, node_size)->right, max_off, node_idx, depth + 1, node_size);
-  return node_idx;
+static inline
+aa_node_t * get_rel_node(aa_tree_t * tree, aa_node_t * node, off_t rel_off) {
+  return (aa_node_t *)((unsigned char *) node + rel_off * tree->node_size);
 }
 
-void aa_error_check(aa_node_t * root, off_t abs_off, off_t max_off, size_t node_size) {
-  aa_error_check_helper(root, abs_off, max_off, 0, 0, node_size);
+static inline
+void * get_data(aa_tree_t * tree, aa_node_t * node) {
+  return (void *)((uintptr_t) node + tree->data_off);
 }
 
-off_t skew(aa_node_t * tree, size_t node_size) {
+off_t skew(aa_tree_t * tree, aa_node_t * node) {
 
-  if (tree->level == get_node(tree, tree->left, node_size)->level) {
-    off_t left = tree->left;
-    tree->left = get_node(tree, left, node_size)->right + left;
-    get_node(tree, left, node_size)->right = -left;
+  if (node->level == get_rel_node(tree, node, node->left)->level) {
+    off_t left = node->left;
+    node->left = get_rel_node(tree, node, left)->right + left;
+    get_rel_node(tree, node, left)->right = -left;
     return left;
   }
   return 0;
 }
 
-off_t split(aa_node_t * tree, size_t node_size) {
-  if (tree->level == get_node(tree, tree->right + get_node(tree, tree->right, node_size)->right, node_size)->level) {
-    off_t right = tree->right;
-    tree->right = get_node(tree, right, node_size)->left + right;
-    get_node(tree, right, node_size)->left = -right;
-    get_node(tree, right, node_size)->level++;
+off_t split(aa_tree_t * tree, aa_node_t * node) {
+  if (node->level == get_rel_node(tree, node, node->right + get_rel_node(tree, node, node->right)->right)->level) {
+    off_t right = node->right;
+    node->right = get_rel_node(tree, node, right)->left + right;
+    get_rel_node(tree, node, right)->left = -right;
+    get_rel_node(tree, node, right)->level++;
     return right;
   }
   return 0;
 }
 
-aa_node_t * successor(aa_node_t * node, size_t node_size) {
-  node = get_node(node, node->right, node_size);
-  while (get_node(node, node->left, node_size)->left != 0 && get_node(node, node->left, node_size)->right != 0) node = get_node(node, node->left, node_size);
-  return node;
+off_t successor(aa_tree_t * tree, off_t abs_off) {
+  aa_node_t * node = get_node(tree, abs_off);
+  abs_off += node->right;
+  node = get_node(tree, abs_off);
+  while (
+    get_node(tree, abs_off + node->left)->left != 0
+    && get_node(tree, abs_off + node->left)->right != 0) {
+    abs_off += node->left;
+    node = get_node(tree, abs_off);
+  }
+  return abs_off;
 }
 
-aa_node_t * predecessor(aa_node_t * node, size_t node_size) {
-  node = get_node(node, node->left, node_size);
-  while (get_node(node, node->right, node_size)->right != 0 && get_node(node, node->right, node_size)->left != 0) node = get_node(node, node->right, node_size);
-  return node;
+off_t predecessor(aa_tree_t * tree, off_t abs_off) {
+  aa_node_t * node = get_node(tree, abs_off);
+  abs_off += node->left;
+  node = get_node(tree, abs_off);
+  while (
+    get_node(tree, abs_off + node->right)->left != 0
+    && get_node(tree, abs_off + node->right)->right != 0) {
+    abs_off += node->right;
+    node = get_node(tree, abs_off);
+  }
+  return abs_off;
 }
 
-void decrease_level(aa_node_t * node, unsigned int node_size) {
+void decrease_level(aa_tree_t * tree, aa_node_t * node) {
    unsigned int correct_level = 1 +
-   (get_node(node, node->left, node_size)->level < get_node(node, node->right, node_size)->level
-   ?get_node(node, node->left, node_size)->level
-   :get_node(node, node->right, node_size)->level)
+   (get_rel_node(tree, node, node->left)->level < get_rel_node(tree, node, node->right)->level
+   ? get_rel_node(tree, node, node->left)->level
+   : get_rel_node(tree, node, node->right)->level)
    ;
 
    if (correct_level < node->level) {
      node->level = correct_level;
-     if (correct_level < get_node(node, node->right, node_size)->level)
-      get_node(node, node->right, node_size)->level = correct_level;
+     if (correct_level < get_rel_node(tree, node, node->right)->level)
+      get_rel_node(tree, node, node->right)->level = correct_level;
    }
    return;
 }
+unsigned int aa_error_check_helper(aa_tree_t * tree, off_t abs_off, off_t max_off, unsigned int agg, unsigned int depth) {
+  if (abs_off == 0) {
+    for (unsigned int i = 0; i < depth; i++) printf("\t");
+    printf("[node %u]: NIL\n", agg);
+    return agg + 1;
+  }
+  if (abs_off < 0 || abs_off > max_off) {
+    for (unsigned int i = 0; i < depth; i++) printf("\t");
+    printf("[node %u]: off %lld out of bounds\n", agg, abs_off);
+    return agg + 1;
+  }
+  if (get_node(tree, abs_off)->left == 0 && get_node(tree, abs_off)->right == 0) return agg;
+  agg = aa_error_check_helper(tree, abs_off + get_node(tree, abs_off)->left, max_off, agg, depth + 1);
+  for (unsigned int i = 0; i < depth; i++) printf("\t");
+  printf("[node %u]: off %lld\n", agg++, abs_off);
+  agg = aa_error_check_helper(tree, abs_off + get_node(tree, abs_off)->right, max_off, agg, depth + 1);
+  return agg;
+}
 
-static
-bool aa_find_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, aa_node_t ** match, size_t node_size) {
-  if (node->left == 0 && node->right == 0) return false;
-  switch (comparator(data, node->data)) {
-    case LT:
-      ;
-      return aa_find_helper(comparator, get_node(node, node->left, node_size), data, match, node_size);
-      break;
+void aa_error_check(aa_tree_t * tree, off_t root, off_t max_off) {
+  aa_error_check_helper(tree, root, max_off, 0, 0);
+}
 
-    case GT:
-      ;
-      return aa_find_helper(comparator, get_node(node, node->right, node_size), data, match, node_size);
-      break;
+bool aa_find(aa_tree_t * tree, off_t root, void * data, void ** match) {
+  aa_node_t * node = get_node(tree, root);
+  while (1) {
+    if (node->left == 0 && node->right == 0) return false;
+    switch (tree->comparator(data, get_data(tree, node))) {
+      case LT:
+        ;
+        node = get_rel_node(tree, node, node->left);
+        break;
 
-    default:
-    case EQ:
-      *match = node;
-      return true;
+      case GT:
+        ;
+        node = get_rel_node(tree, node, node->right);
+        break;
+
+      default:
+      case EQ:
+        ;
+        *match = get_data(tree, node);
+        return true;
+    }
   }
 }
 
-bool aa_find(compare_t (* comparator) (void * a, void * b), aa_node_t * tree, off_t root, void * data, aa_node_t ** match, size_t node_size) {
-  return aa_find_helper(comparator, get_node(tree, root, node_size), data, match, node_size);
-}
-
 static
-off_t aa_insert_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, aa_node_t * to, off_t to_off, size_t node_size) {
-//   printf("to_off %ld\n", to_off);
+off_t aa_insert_helper(aa_tree_t * tree, aa_node_t * node, aa_node_t * to, off_t to_off) {
   if ((node)->left == 0 && (node)->right == 0) {
-//     printf("node is NIL\n");
     *to = (aa_node_t) {
       .left = -to_off,
       .right = -to_off,
-      .data = data,
       .level = 1
     };
-    node = to;
-    off_t skew_off = skew(node, node_size);
-//     printf("skew_off %ld\n", skew_off);
-    off_t split_off = split(get_node(node, skew_off, node_size), node_size);
-//     printf("split_off %ld\n", split_off);
+    off_t skew_off = skew(tree, to);
+    off_t split_off = split(tree, get_rel_node(tree, to, skew_off));
     return to_off + skew_off + split_off;
   }
 
-  switch (comparator(data, node->data)) {
+  switch (tree->comparator(get_data(tree, to), get_data(tree, node))) {
     case LT:
       ;
-//       printf("LT %ld\n", node->left);
-      node->left += aa_insert_helper(comparator, get_node(node, node->left, node_size), data, to, to_off, node_size);
-//       printf("LEFT THEN: %ld\n", node->left);
+      node->left += aa_insert_helper(tree, get_rel_node(tree, node, node->left), to, to_off);
       break;
 
     case GT:
       ;
-//       printf("GT %ld\n", node->right);
-      node->right += aa_insert_helper(comparator, get_node(node, node->right, node_size), data, to, to_off, node_size);
-//       printf("RIGHT THEN: %ld\n", node->right);
+      node->right += aa_insert_helper(tree, get_rel_node(tree, node, node->right), to, to_off);
       break;
 
     default:
@@ -144,64 +157,90 @@ off_t aa_insert_helper(compare_t (* comparator) (void * a, void * b), aa_node_t 
       printf("[aa_tree] [ANGRY]: Inserting a node which exists in the tree\n");
   }
 
-  off_t skew_off = skew(node, node_size);
-//   printf("skew_off %ld\n", skew_off);
-  off_t split_off = split(get_node(node, skew_off, node_size), node_size);
-//   printf("split_off %ld\n", split_off);
+  off_t skew_off = skew(tree, node);
+  off_t split_off = split(tree, get_rel_node(tree, node, skew_off));
   return skew_off + split_off;
-//   return abs_off + split(node + skew(node));
 }
 
-void aa_insert(compare_t (* comparator) (void * a, void * b), aa_node_t * tree, off_t * root, void * data, off_t to_off, size_t node_size) {
-//   printf("starting root %ld\n", *root);
-  *root += aa_insert_helper(comparator, get_node(tree, *root, node_size), data, get_node(tree, to_off, node_size), to_off, node_size);
-//   printf("ending root %ld\n", *root);
+void aa_insert(aa_tree_t * tree, off_t * root, off_t to) {
+  *root += aa_insert_helper(tree, get_node(tree, *root), get_node(tree, to), to);
 }
 
 static
-off_t aa_delete_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, off_t abs_off, size_t node_size) {
+off_t aa_delete_helper(aa_tree_t * tree, off_t abs_off, void * data) {
+  aa_node_t * node = get_node(tree, abs_off);
+  off_t delta_off = 0;
   if (node->left == 0 && node->right == 0) return 0;
-  switch (comparator(data, node->data)) {
+  switch (tree->comparator(data, get_data(tree, node))) {
     case LT:
       ;
-      node->left += aa_delete_helper(comparator, get_node(node, node->left, node_size), data, abs_off - node->left, node_size);
+      node->left += aa_delete_helper(tree, abs_off + node->left, data);
       break;
 
     case GT:
       ;
-      node->right += aa_delete_helper(comparator, get_node(node, node->right, node_size), data, abs_off - node->right, node_size);
+      node->right += aa_delete_helper(tree, abs_off + node->right, data);
       break;
 
     default:
     case EQ:
-      if (get_node(node, node->left, node_size)->left == 0 && get_node(node, node->left, node_size)->right == 0 && get_node(node, node->right, node_size)->left == 0 && get_node(node, node->right, node_size)->right == 0) {
-        printf("free(node)\n");
-//         free(node);
+      ;
+      aa_node_t * left = get_node(tree, abs_off + node->left);
+      aa_node_t * right = get_node(tree, abs_off + node->right);
+      if (
+        left->left   == 0 &&
+        left->right  == 0 &&
+        right->left  == 0 &&
+        right->right == 0) {
         return -abs_off;
       }
-      else if (get_node(node, node->left, node_size)->left == 0 && get_node(node, node->left, node_size)->right == 0) {
-        aa_node_t * succ = successor(node, node_size);
-        node->data = succ->data;
-        node->right += aa_delete_helper(comparator, get_node(node, node->right, node_size), succ->data, abs_off - node->right, node_size);
+      else if (left->left == 0 && left->right == 0) {
+        off_t succ = successor(tree, abs_off);
+        delta_off = succ - abs_off;
+        off_t right = abs_off + node->right;
+        node->right += delta_off;
+        node->right += aa_delete_helper(tree, right, data);
       } else {
-        aa_node_t * pred = predecessor(node, node_size);
-        node->data = pred->data;
-        node->left += aa_delete_helper(comparator, get_node(node, node->left, node_size), pred->data, abs_off - node->left, node_size);
+        off_t pred = predecessor(tree, abs_off);
+        delta_off = pred - abs_off;
+        off_t left = abs_off + node->left;
+        node->left += delta_off;
+        node->left += aa_delete_helper(tree, left, data);
       }
       break;
   }
 
-  decrease_level(node, node_size);
-  off_t skew_off = skew(node, node_size);
+  decrease_level(tree, node);
+  off_t skew_off = skew(tree, node);
   node += skew_off;
-  node->right += skew(get_node(node, node->right, node_size), node_size);
-  get_node(node, node->right, node_size)->right += skew(get_node(node, get_node(node, node->right, node_size)->right, node_size), node_size);
-  off_t split_off = split(node, node_size);
-  node = get_node(node, split_off, node_size);
-  node->right += split(get_node(node, node->right, node_size), node_size);
-  return skew_off + split_off;
+  node->right += skew(tree, get_rel_node(tree, node, node->right));
+  get_rel_node(tree, node, node->right)->right += skew(tree, get_rel_node(tree, node, get_rel_node(tree, node, node->right)->right));
+  off_t split_off = split(tree, node);
+  node = get_rel_node(tree, node, split_off);
+  node->right += split(tree, get_rel_node(tree, node, node->right));
+  return skew_off + split_off + delta_off;
 }
 
-void aa_delete(compare_t (* comparator) (void * a, void * b), aa_node_t * tree,  off_t * root, void * data, size_t node_size) {
-  *root += aa_delete_helper(comparator, get_node(tree, *root, node_size), data, *root, node_size);
+void aa_delete(aa_tree_t * tree, off_t * root, void * data) {
+  *root += aa_delete_helper(tree, *root, data);
+}
+
+aa_tree_t create_aa_tree(void * node_root, size_t node_size, void * data_root,
+                         compare_t (* comparator) (void * a, void * b)) {
+  aa_tree_t tree = (aa_tree_t) {
+    .node_root = node_root,
+    .node_size = node_size,
+    .data_off = (uintptr_t) data_root - (uintptr_t) node_root,
+
+    .comparator = comparator,
+  };
+
+  return tree;
+}
+
+aa_tree_t * rebase_aa_tree(aa_tree_t * tree, void * node_root, void * data_root) {
+  tree->node_root = node_root;
+  tree->data_off = (uintptr_t) data_root - (uintptr_t) node_root;
+
+  return tree;
 }

--- a/math/aa_tree.c
+++ b/math/aa_tree.c
@@ -2,7 +2,12 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-unsigned int aa_error_check_helper(aa_node_t * root, off_t abs_off, off_t max_off, unsigned int node_idx, unsigned int depth) {
+static inline
+aa_node_t * get_node(aa_node_t * node, off_t abs_off, size_t node_size) {
+  return (aa_node_t *)((unsigned char *) node + abs_off * node_size);
+}
+
+unsigned int aa_error_check_helper(aa_node_t * root, off_t abs_off, off_t max_off, unsigned int node_idx, unsigned int depth, size_t node_size) {
   if (abs_off == 0) {
     for (unsigned int i = 0; i < depth; i++) printf("\t");
     printf("[node %u]: NIL\n", node_idx);
@@ -10,82 +15,82 @@ unsigned int aa_error_check_helper(aa_node_t * root, off_t abs_off, off_t max_of
   }
   if (abs_off < 0 || abs_off > max_off) {
     for (unsigned int i = 0; i < depth; i++) printf("\t");
-    printf("[node %u]: off %ld out of bounds\n", node_idx, abs_off);
+    printf("[node %u]: off %lld out of bounds\n", node_idx, abs_off);
     return node_idx + 1;
   }
-  if ((root + abs_off)->left == 0 && (root + abs_off)->right == 0) return node_idx;
-  node_idx = aa_error_check_helper(root, abs_off + (root + abs_off)->left, max_off, node_idx, depth + 1);
+  if (get_node(root, abs_off, node_size)->left == 0 && get_node(root, abs_off, node_size)->right == 0) return node_idx;
+  node_idx = aa_error_check_helper(root, abs_off + get_node(root, abs_off, node_size)->left, max_off, node_idx, depth + 1, node_size);
   for (unsigned int i = 0; i < depth; i++) printf("\t");
-  printf("[node %u]: off %ld\n", node_idx++, abs_off);
-  node_idx = aa_error_check_helper(root, abs_off + (root + abs_off)->right, max_off, node_idx, depth + 1);
+  printf("[node %u]: off %lld\n", node_idx++, abs_off);
+  node_idx = aa_error_check_helper(root, abs_off + get_node(root, abs_off, node_size)->right, max_off, node_idx, depth + 1, node_size);
   return node_idx;
 }
 
-void aa_error_check(aa_node_t * root, off_t abs_off, off_t max_off) {
-//   printf("abs_off %ld, max_off %ld\n", abs_off, max_off);
-  aa_error_check_helper(root, abs_off, max_off, 0, 0);
+void aa_error_check(aa_node_t * root, off_t abs_off, off_t max_off, size_t node_size) {
+  aa_error_check_helper(root, abs_off, max_off, 0, 0, node_size);
 }
 
-off_t skew(aa_node_t * tree) {
-  if (tree->level == (tree + tree->left)->level) {
+off_t skew(aa_node_t * tree, size_t node_size) {
+
+  if (tree->level == get_node(tree, tree->left, node_size)->level) {
     off_t left = tree->left;
-    tree->left = (tree + left)->right + left;
-    (tree + left)->right = -left;
+    tree->left = get_node(tree, left, node_size)->right + left;
+    get_node(tree, left, node_size)->right = -left;
     return left;
   }
   return 0;
 }
 
-off_t split(aa_node_t * tree) {
-  if (tree->level == (tree + tree->right + (tree + tree->right)->right)->level) {
+off_t split(aa_node_t * tree, size_t node_size) {
+  if (tree->level == get_node(tree, tree->right + get_node(tree, tree->right, node_size)->right, node_size)->level) {
     off_t right = tree->right;
-    tree->right = (tree + right)->left + right;
-    (tree + right)->left = -right;
-    (tree + right)->level++;
+    tree->right = get_node(tree, right, node_size)->left + right;
+    get_node(tree, right, node_size)->left = -right;
+    get_node(tree, right, node_size)->level++;
     return right;
   }
   return 0;
 }
 
-aa_node_t * successor(aa_node_t * node) {
-  node = (node + node->right);
-  while ((node + node->left)->left != 0 && (node + node->left)->right != 0) node = (node + node->left);
+aa_node_t * successor(aa_node_t * node, size_t node_size) {
+  node = get_node(node, node->right, node_size);
+  while (get_node(node, node->left, node_size)->left != 0 && get_node(node, node->left, node_size)->right != 0) node = get_node(node, node->left, node_size);
   return node;
 }
 
-aa_node_t * predecessor(aa_node_t * node) {
-  node = (node + node->left);
-  while ((node + node->right)->right != 0 && (node + node->right)->left != 0) node = (node + node->right);
+aa_node_t * predecessor(aa_node_t * node, size_t node_size) {
+  node = get_node(node, node->left, node_size);
+  while (get_node(node, node->right, node_size)->right != 0 && get_node(node, node->right, node_size)->left != 0) node = get_node(node, node->right, node_size);
   return node;
 }
 
-void decrease_level(aa_node_t * node) {
+void decrease_level(aa_node_t * node, unsigned int node_size) {
    unsigned int correct_level = 1 +
-   ((node + node->left)->level < (node + node->right)->level
-   ?(node + node->left)->level
-   :(node + node->right)->level)
+   (get_node(node, node->left, node_size)->level < get_node(node, node->right, node_size)->level
+   ?get_node(node, node->left, node_size)->level
+   :get_node(node, node->right, node_size)->level)
    ;
 
    if (correct_level < node->level) {
      node->level = correct_level;
-     if (correct_level < (node + node->right)->level)
-      (node + node->right)->level = correct_level;
+     if (correct_level < get_node(node, node->right, node_size)->level)
+      get_node(node, node->right, node_size)->level = correct_level;
    }
    return;
 }
 
 static
-bool aa_find_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, aa_node_t ** match) {
+bool aa_find_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, aa_node_t ** match, size_t node_size) {
   if (node->left == 0 && node->right == 0) return false;
   switch (comparator(data, node->data)) {
     case LT:
       ;
-      return aa_find_helper(comparator, (node + node->left), data, match);
+      return aa_find_helper(comparator, get_node(node, node->left, node_size), data, match, node_size);
       break;
 
     case GT:
       ;
-      return aa_find_helper(comparator, (node + node->right), data, match);
+      return aa_find_helper(comparator, get_node(node, node->right, node_size), data, match, node_size);
       break;
 
     default:
@@ -95,12 +100,12 @@ bool aa_find_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * n
   }
 }
 
-bool aa_find(compare_t (* comparator) (void * a, void * b), aa_node_t * root, void * data, aa_node_t ** match) {
-  return aa_find_helper(comparator, root, data, match);
+bool aa_find(compare_t (* comparator) (void * a, void * b), aa_node_t * tree, off_t root, void * data, aa_node_t ** match, size_t node_size) {
+  return aa_find_helper(comparator, get_node(tree, root, node_size), data, match, node_size);
 }
 
 static
-off_t aa_insert_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, aa_node_t * to, off_t to_off) {
+off_t aa_insert_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, aa_node_t * to, off_t to_off, size_t node_size) {
 //   printf("to_off %ld\n", to_off);
   if ((node)->left == 0 && (node)->right == 0) {
 //     printf("node is NIL\n");
@@ -111,9 +116,9 @@ off_t aa_insert_helper(compare_t (* comparator) (void * a, void * b), aa_node_t 
       .level = 1
     };
     node = to;
-    off_t skew_off = skew(node);
+    off_t skew_off = skew(node, node_size);
 //     printf("skew_off %ld\n", skew_off);
-    off_t split_off = split(node + skew_off);
+    off_t split_off = split(get_node(node, skew_off, node_size), node_size);
 //     printf("split_off %ld\n", split_off);
     return to_off + skew_off + split_off;
   }
@@ -122,14 +127,14 @@ off_t aa_insert_helper(compare_t (* comparator) (void * a, void * b), aa_node_t 
     case LT:
       ;
 //       printf("LT %ld\n", node->left);
-      node->left += aa_insert_helper(comparator, (node + node->left), data, to, to_off);
+      node->left += aa_insert_helper(comparator, get_node(node, node->left, node_size), data, to, to_off, node_size);
 //       printf("LEFT THEN: %ld\n", node->left);
       break;
 
     case GT:
       ;
 //       printf("GT %ld\n", node->right);
-      node->right += aa_insert_helper(comparator, (node + node->right), data, to, to_off);
+      node->right += aa_insert_helper(comparator, get_node(node, node->right, node_size), data, to, to_off, node_size);
 //       printf("RIGHT THEN: %ld\n", node->right);
       break;
 
@@ -139,64 +144,64 @@ off_t aa_insert_helper(compare_t (* comparator) (void * a, void * b), aa_node_t 
       printf("[aa_tree] [ANGRY]: Inserting a node which exists in the tree\n");
   }
 
-  off_t skew_off = skew(node);
+  off_t skew_off = skew(node, node_size);
 //   printf("skew_off %ld\n", skew_off);
-  off_t split_off = split(node + skew_off);
+  off_t split_off = split(get_node(node, skew_off, node_size), node_size);
 //   printf("split_off %ld\n", split_off);
   return skew_off + split_off;
 //   return abs_off + split(node + skew(node));
 }
 
-void aa_insert(compare_t (* comparator) (void * a, void * b), off_t * root, aa_node_t * tree, void * data, off_t to_off) {
+void aa_insert(compare_t (* comparator) (void * a, void * b), aa_node_t * tree, off_t * root, void * data, off_t to_off, size_t node_size) {
 //   printf("starting root %ld\n", *root);
-  *root += aa_insert_helper(comparator, (tree + *root), data, tree + to_off, to_off);
+  *root += aa_insert_helper(comparator, get_node(tree, *root, node_size), data, get_node(tree, to_off, node_size), to_off, node_size);
 //   printf("ending root %ld\n", *root);
 }
 
 static
-off_t aa_delete_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, off_t abs_off) {
+off_t aa_delete_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, off_t abs_off, size_t node_size) {
   if (node->left == 0 && node->right == 0) return 0;
   switch (comparator(data, node->data)) {
     case LT:
       ;
-      node->left += aa_delete_helper(comparator, (node + node->left), data, abs_off - node->left);
+      node->left += aa_delete_helper(comparator, get_node(node, node->left, node_size), data, abs_off - node->left, node_size);
       break;
 
     case GT:
       ;
-      node->right += aa_delete_helper(comparator, (node + node->right), data, abs_off - node->right);
+      node->right += aa_delete_helper(comparator, get_node(node, node->right, node_size), data, abs_off - node->right, node_size);
       break;
 
     default:
     case EQ:
-      if ((node + node->left)->left == 0 && (node + node->left)->right == 0 && (node + node->right)->left == 0 && (node + node->right)->right == 0) {
+      if (get_node(node, node->left, node_size)->left == 0 && get_node(node, node->left, node_size)->right == 0 && get_node(node, node->right, node_size)->left == 0 && get_node(node, node->right, node_size)->right == 0) {
         printf("free(node)\n");
 //         free(node);
         return -abs_off;
       }
-      else if ((node + node->left)->left == 0 && (node + node->left)->right == 0) {
-        aa_node_t * succ = successor(node);
+      else if (get_node(node, node->left, node_size)->left == 0 && get_node(node, node->left, node_size)->right == 0) {
+        aa_node_t * succ = successor(node, node_size);
         node->data = succ->data;
-        node->right += aa_delete_helper(comparator, (node + node->right), succ->data, abs_off - node->right);
+        node->right += aa_delete_helper(comparator, get_node(node, node->right, node_size), succ->data, abs_off - node->right, node_size);
       } else {
-        aa_node_t * pred = predecessor(node);
+        aa_node_t * pred = predecessor(node, node_size);
         node->data = pred->data;
-        node->left += aa_delete_helper(comparator, node + node->left, pred->data, abs_off - node->left);
+        node->left += aa_delete_helper(comparator, get_node(node, node->left, node_size), pred->data, abs_off - node->left, node_size);
       }
       break;
   }
 
-  decrease_level(node);
-  off_t skew_off = skew(node);
+  decrease_level(node, node_size);
+  off_t skew_off = skew(node, node_size);
   node += skew_off;
-  node->right += skew(node + node->right);
-  (node + node->right)->right += skew(node + (node + node->right)->right);
-  off_t split_off = split(node);
-  node += split_off;
-  node->right += split(node + node->right);
+  node->right += skew(get_node(node, node->right, node_size), node_size);
+  get_node(node, node->right, node_size)->right += skew(get_node(node, get_node(node, node->right, node_size)->right, node_size), node_size);
+  off_t split_off = split(node, node_size);
+  node = get_node(node, split_off, node_size);
+  node->right += split(get_node(node, node->right, node_size), node_size);
   return skew_off + split_off;
 }
 
-void aa_delete(compare_t (* comparator) (void * a, void * b), off_t * root, aa_node_t * tree, void * data) {
-  *root += aa_delete_helper(comparator, tree + *root, data, *root);
+void aa_delete(compare_t (* comparator) (void * a, void * b), aa_node_t * tree,  off_t * root, void * data, size_t node_size) {
+  *root += aa_delete_helper(comparator, get_node(tree, *root, node_size), data, *root, node_size);
 }

--- a/math/aa_tree.c
+++ b/math/aa_tree.c
@@ -2,65 +2,91 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-aa_node_t * skew(aa_node_t * tree) {
-  if (tree->level == tree->left->level) {
-    aa_node_t * left = tree->left;
-    tree->left = left->right;
-    left->right = tree;
+unsigned int aa_error_check_helper(aa_node_t * root, off_t abs_off, off_t max_off, unsigned int node_idx, unsigned int depth) {
+  if (abs_off == 0) {
+    for (unsigned int i = 0; i < depth; i++) printf("\t");
+    printf("[node %u]: NIL\n", node_idx);
+    return node_idx + 1;
+  }
+  if (abs_off < 0 || abs_off > max_off) {
+    for (unsigned int i = 0; i < depth; i++) printf("\t");
+    printf("[node %u]: off %ld out of bounds\n", node_idx, abs_off);
+    return node_idx + 1;
+  }
+  if ((root + abs_off)->left == 0 && (root + abs_off)->right == 0) return node_idx;
+  node_idx = aa_error_check_helper(root, abs_off + (root + abs_off)->left, max_off, node_idx, depth + 1);
+  for (unsigned int i = 0; i < depth; i++) printf("\t");
+  printf("[node %u]: off %ld\n", node_idx++, abs_off);
+  node_idx = aa_error_check_helper(root, abs_off + (root + abs_off)->right, max_off, node_idx, depth + 1);
+  return node_idx;
+}
+
+void aa_error_check(aa_node_t * root, off_t abs_off, off_t max_off) {
+  printf("abs_off %ld, max_off %ld\n", abs_off, max_off);
+  aa_error_check_helper(root, abs_off, max_off, 0, 0);
+}
+
+off_t skew(aa_node_t * tree) {
+  printf("tree level %u, tree left level %u\n", tree->level, (tree + tree->left)->level);
+  if (tree->level == (tree + tree->left)->level) {
+    off_t left = tree->left;
+    tree->left = (tree + left)->right + left;
+    (tree + left)->right = -left;
     return left;
   }
-  return tree;
+  return 0;
 }
 
-aa_node_t * split(aa_node_t * tree) {
-  if (tree->level == tree->right->right->level) {
-    aa_node_t * right = tree->right;
-    tree->right = right->left;
-    right->left = tree;
-    right->level++;
+off_t split(aa_node_t * tree) {
+  if (tree->level == (tree + tree->right + (tree + tree->right)->right)->level) {
+    off_t right = tree->right;
+    tree->right = (tree + right)->left + right;
+    (tree + right)->left = -right;
+    (tree + right)->level++;
     return right;
   }
-  return tree;
+  return 0;
 }
 
-aa_node_t * successor(aa_node_t * node, aa_node_t * nil) {
-  node = node->right;
-  while (node->left != nil) node = node->left;
+aa_node_t * successor(aa_node_t * node) {
+  node = (node + node->right);
+  while ((node + node->left)->left != 0 && (node + node->left)->right != 0) node = (node + node->left);
   return node;
 }
 
-aa_node_t * predecessor(aa_node_t * node, aa_node_t * nil) {
-  node = node->left;
-  while (node->right != nil) node = node->right;
+aa_node_t * predecessor(aa_node_t * node) {
+  node = (node + node->left);
+  while ((node + node->right)->right != 0 && (node + node->right)->left != 0) node = (node + node->right);
   return node;
 }
 
 aa_node_t * decrease_level(aa_node_t * node) {
-   unsigned int correct_level =
-   (node->left->level < node->right->level ?
-    node->left->level                      :
-    node->right->level                     ) + 1;
+   unsigned int correct_level = 1 +
+   ((node + node->left)->level < (node + node->right)->level
+   ?(node + node->left)->level
+   :(node + node->right)->level)
+   ;
 
    if (correct_level < node->level) {
      node->level = correct_level;
-     if (correct_level < node->right->level)
-      node->right->level = correct_level;
+     if (correct_level < (node + node->right)->level)
+      (node + node->right)->level = correct_level;
    }
    return node;
 }
 
 static
-bool aa_find_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * nil, aa_node_t * node, void * data, aa_node_t ** match) {
-  if (node == nil) return false;
+bool aa_find_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, aa_node_t ** match) {
+  if (node->left == 0 && node->right == 0) return false;
   switch (comparator(data, node->data)) {
     case LT:
       ;
-      return aa_find_helper(comparator, nil, node->left, data, match);
+      return aa_find_helper(comparator, (node + node->left), data, match);
       break;
 
     case GT:
       ;
-      return aa_find_helper(comparator, nil, node->right, data, match);
+      return aa_find_helper(comparator, (node + node->right), data, match);
       break;
 
     default:
@@ -70,32 +96,42 @@ bool aa_find_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * n
   }
 }
 
-bool aa_find(aa_tree_t * tree, void * data, aa_node_t ** match) {
-  return aa_find_helper(tree->comparator, &(tree->nil), tree->root, data, match);
+bool aa_find(compare_t (* comparator) (void * a, void * b), aa_node_t * root, void * data, aa_node_t ** match) {
+  return aa_find_helper(comparator, root, data, match);
 }
 
 static
-aa_node_t * aa_insert_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * nil, aa_node_t * node, void * data, aa_node_t * to) {
-  if (node == nil) {
+off_t aa_insert_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, aa_node_t * to, off_t to_off) {
+  printf("to_off %ld\n", to_off);
+  if ((node)->left == 0 && (node)->right == 0) {
+    printf("node is NIL\n");
     *to = (aa_node_t) {
-      .left = nil,
-      .right = nil,
+      .left = -to_off,
+      .right = -to_off,
       .data = data,
       .level = 1
     };
     node = to;
-    return split(skew(node));
+    off_t skew_off = skew(node);
+    printf("skew_off %ld\n", skew_off);
+    off_t split_off = split(node + skew_off);
+    printf("split_off %ld\n", split_off);
+    return to_off + split_off;
   }
 
   switch (comparator(data, node->data)) {
     case LT:
       ;
-      node->left = aa_insert_helper(comparator, nil, node->left, data, to);
+      printf("LT %ld\n", node->left);
+      node->left += aa_insert_helper(comparator, (node + node->left), data, to, to_off);
+      printf("LEFT THEN: %ld\n", node->left);
       break;
 
     case GT:
       ;
-      node->right = aa_insert_helper(comparator, nil, node->right, data, to);
+      printf("GT %ld\n", node->right);
+      node->right += aa_insert_helper(comparator, (node + node->right), data, to, to_off);
+      printf("RIGHT THEN: %ld\n", node->right);
       break;
 
     default:
@@ -103,54 +139,65 @@ aa_node_t * aa_insert_helper(compare_t (* comparator) (void * a, void * b), aa_n
       ;
       printf("[aa_tree] [ANGRY]: Inserting a node which exists in the tree\n");
   }
-  return split(skew(node));
+
+  off_t skew_off = skew(node);
+  printf("skew_off %ld\n", skew_off);
+  off_t split_off = split(node + skew_off);
+  printf("split_off %ld\n", split_off);
+  return split_off;
+//   return abs_off + split(node + skew(node));
 }
 
-void aa_insert(aa_tree_t * tree, void * data, aa_node_t * to) {
-  tree->root = aa_insert_helper(tree->comparator, &(tree->nil), tree->root, data, to);
+void aa_insert(compare_t (* comparator) (void * a, void * b), off_t * root, aa_node_t * tree, void * data, off_t to_off) {
+  printf("starting root %ld\n", *root);
+  *root += aa_insert_helper(comparator, (tree + *root), data, tree + to_off, to_off);
+  printf("ending root %ld\n", *root);
 }
 
 static
-aa_node_t * aa_delete_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * nil, aa_node_t * node, void * data) {
-  if (node == nil) return nil;
+off_t aa_delete_helper(compare_t (* comparator) (void * a, void * b), aa_node_t * node, void * data, off_t nil_off) {
+  if ((node)->left == 0 && (node)->right == 0) return 0;
   switch (comparator(data, node->data)) {
     case LT:
       ;
-      node->left = aa_delete_helper(comparator, nil, node->left, data);
+      node->left += aa_delete_helper(comparator, (node + node->left), data, nil_off - node->left);
       break;
 
     case GT:
       ;
-      node->right = aa_delete_helper(comparator, nil, node->right, data);
+      node->right += aa_delete_helper(comparator, (node + node->right), data, nil_off - node->right);
       break;
 
     default:
     case EQ:
-      if (node->left == nil && node->right == nil) {
-        // printf("free(node)\n");
-        free(node);
-        return nil;
+      if ((node + node->left)->left == 0 && (node + node->left)->right == 0 && (node + node->right)->left == 0 && (node + node->right)->right == 0) {
+        printf("free(node)\n");
+//         free(node);
+        return nil_off;
       }
-      else if (node->left == nil) {
-        aa_node_t * succ = successor(node, nil);
+      else if ((node + node->left)->left == 0 && (node + node->left)->right == 0) {
+        aa_node_t * succ = successor(node);
         node->data = succ->data;
-        node->right = aa_delete_helper(comparator, nil, node->right, succ->data);
+        node->right += aa_delete_helper(comparator, (node + node->right), succ->data, nil_off - node->right);
       } else {
-        aa_node_t * pred = predecessor(node, nil);
+        aa_node_t * pred = predecessor(node);
         node->data = pred->data;
-        node->left = aa_delete_helper(comparator, nil, node->left, pred->data);
+        node->left += aa_delete_helper(comparator, node + node->left, pred->data, nil_off - node->left);
       }
       break;
   }
+
   node = decrease_level(node);
-  node = skew(node);
-  node->right = skew(node->right);
-  node->right->right = skew(node->right->right);
-  node = split(node);
-  node->right = split(node->right);
-  return node;
+  off_t skew_off = skew(node);
+  node += skew_off;
+  node->right += skew(node + node->right);
+  (node + node->right)->right += skew(node + (node + node->right)->right);
+  off_t split_off = split(node);
+  node += split_off;
+  node->right += split(node + node->right);
+  return skew_off + split_off;
 }
 
-void aa_delete(aa_tree_t * tree, void * data) {
-  tree->root = aa_delete_helper(tree->comparator, &(tree->nil), tree->root, data);
+void aa_delete(compare_t (* comparator) (void * a, void * b), off_t * root, aa_node_t * tree, void * data) {
+  *root = aa_delete_helper(comparator, tree + *root, data, -*root);
 }

--- a/math/aa_tree.h
+++ b/math/aa_tree.h
@@ -23,9 +23,9 @@ aa_node_t;
 
 
 
-bool aa_find(compare_t (* comparator) (void * a, void * b), aa_node_t * root, void * data, aa_node_t ** match);
-void aa_insert(compare_t (* comparator) (void * a, void * b), off_t * root, aa_node_t * tree, void * data, off_t to);
-void aa_delete(compare_t (* comparator) (void * a, void * b), off_t * root, aa_node_t * tree, void * data);
-void aa_error_check(aa_node_t * root, off_t abs_off, off_t max_off);
+bool aa_find(compare_t (* comparator) (void * a, void * b), aa_node_t * tree, off_t root, void * data, aa_node_t ** match, size_t node_size);
+void aa_insert(compare_t (* comparator) (void * a, void * b), aa_node_t * tree, off_t * root, void * data, off_t to, size_t node_size);
+void aa_delete(compare_t (* comparator) (void * a, void * b), aa_node_t * tree, off_t * root, void * data, size_t node_size);
+void aa_error_check(aa_node_t * root, off_t abs_off, off_t max_off, size_t node_size);
 
 #endif /* end of include guard: AA_TREE_H */

--- a/math/aa_tree.h
+++ b/math/aa_tree.h
@@ -16,16 +16,30 @@ typedef
 struct aa_node_s {
   off_t left;
   off_t right;
-  void * data;
   unsigned int level;
 }
 aa_node_t;
 
+typedef
+struct aa_tree_s {
+  /* node storage */
+  void * node_root;
+  size_t node_size;
+  /* data storage */
+  uintptr_t data_off;
+
+  compare_t (* comparator) (void * a,    void * b);
+}
+aa_tree_t;
 
 
-bool aa_find(compare_t (* comparator) (void * a, void * b), aa_node_t * tree, off_t root, void * data, aa_node_t ** match, size_t node_size);
-void aa_insert(compare_t (* comparator) (void * a, void * b), aa_node_t * tree, off_t * root, void * data, off_t to, size_t node_size);
-void aa_delete(compare_t (* comparator) (void * a, void * b), aa_node_t * tree, off_t * root, void * data, size_t node_size);
-void aa_error_check(aa_node_t * root, off_t abs_off, off_t max_off, size_t node_size);
+bool aa_find(aa_tree_t * tree, off_t root, void * data, void ** match);
+void aa_insert(aa_tree_t * tree, off_t * root, off_t to);
+void aa_delete(aa_tree_t * tree, off_t * root, void * data);
+void aa_error_check(aa_tree_t * tree, off_t root, off_t max_off);
 
+aa_tree_t create_aa_tree(void * node_root, size_t node_size, void * data_root,
+                         compare_t (* comparator) (void * a, void * b));
+
+aa_tree_t * rebase_aa_tree(aa_tree_t * tree, void * node_root, void * data_root);
 #endif /* end of include guard: AA_TREE_H */

--- a/math/aa_tree.h
+++ b/math/aa_tree.h
@@ -2,6 +2,7 @@
 #define AA_TREE_H
 
 #include <stdbool.h>
+#include <sys/types.h>
 
 typedef
 enum compare_e {
@@ -13,24 +14,18 @@ compare_t;
 
 typedef
 struct aa_node_s {
-  struct aa_node_s * left;
-  struct aa_node_s * right;
+  off_t left;
+  off_t right;
   void * data;
   unsigned int level;
 }
 aa_node_t;
 
-typedef
-struct aa_tree_s {
-  compare_t (*comparator) (void * a, void * b);
-  aa_node_t * root;
-  aa_node_t nil;
-}
-aa_tree_t;
 
 
-bool aa_find(aa_tree_t * tree, void * data, aa_node_t ** match);
-void aa_insert(aa_tree_t * tree, void * data, aa_node_t * to);
-void aa_delete(aa_tree_t * tree, void * data);
+bool aa_find(compare_t (* comparator) (void * a, void * b), aa_node_t * root, void * data, aa_node_t ** match);
+void aa_insert(compare_t (* comparator) (void * a, void * b), off_t * root, aa_node_t * tree, void * data, off_t to);
+void aa_delete(compare_t (* comparator) (void * a, void * b), off_t * root, aa_node_t * tree, void * data);
+void aa_error_check(aa_node_t * root, off_t abs_off, off_t max_off);
 
 #endif /* end of include guard: AA_TREE_H */

--- a/objects/ship/ship.c
+++ b/objects/ship/ship.c
@@ -121,3 +121,24 @@ object_t create_ship(SGVec3D_t origin, chunk_coord_t abs_coord) {
     }
   };
 }
+
+void load_ship(object_t * ship, user_data_t * user_data) {
+  *ship = (object_t) {
+    .radius = SGVec_Load_Const(30),
+    .distance = distance,
+    .color = color,
+    .ship = (ship_t) {
+      .orientation = DEFAULT_ORIENTATION,
+      .la = SGVec_Load_Const(24.),
+      .lb = SGVec_Load_Const(12.),
+      .height = SGVec_Load_Const(1.),
+      .rot_quats = DEFAULT_ROT_QUAT,
+      .vision = STANDARD,
+    }
+  };
+
+  ship->origin = user_data->origin;
+  ship->ship.abs_coord = user_data->abs_coord;
+}
+
+// void save_ship()

--- a/objects/ship/ship.h
+++ b/objects/ship/ship.h
@@ -3,7 +3,7 @@
 
 #include "../../math/vector_3d.h"
 #include "../../world/chunk.h"
-
+#include "../../users/user_db.h"
 
 typedef
 struct orientation_s {
@@ -36,6 +36,7 @@ ship_t;
 #include "../object.h"
 
 object_t create_ship(SGVec3D_t origin, chunk_coord_t abs_coord);
+void load_ship(object_t * ship, user_data_t * user_data);
 
 #define DEFAULT_ORIENTATION \
 (orientation_t) { \

--- a/render/render.c
+++ b/render/render.c
@@ -105,7 +105,6 @@ march_result_t ray_march(SGVec3D_t origin, SGVec3D_t rays, world_snapshot_t * sn
 
 raw_pixel_t rays_to_pixel(SGVec3D_t rays, world_snapshot_t * snapshot) {
   //outgoing march
-  // printf("trying to go out\n");
   march_result_t march_result = ray_march(snapshot->self->origin, rays, snapshot, snapshot->self);
 
   if (lanes_false(march_result.validity)) {

--- a/ssh/callbacks/session.c
+++ b/ssh/callbacks/session.c
@@ -43,7 +43,7 @@ int auth_password_callback(ssh_session session, const char *user, const char *pa
   }
 
   off_t user_index = login(user, password);
-  printf("\t[ssh_client %u]: user_index: %ld", ssh_client->id, user_index);
+  printf("\t[ssh_client %u]: user_index: %lld\n", ssh_client->id, user_index);
   if(user_index >= 0) {
     ssh_client->authenticated = true;
     ssh_client->user_index = user_index;

--- a/users/.gitignore
+++ b/users/.gitignore
@@ -2,5 +2,5 @@
 !*
 
 # Except this file
-users.database
+*.database
 

--- a/users/user_db.c
+++ b/users/user_db.c
@@ -29,7 +29,7 @@ user_t;
 typedef
 struct user_index_s {
   unsigned int num_users;
-  aa_tree_t data;
+//   aa_tree_t data;
   user_t backing_nodes[];
 }
 user_index_t;
@@ -61,7 +61,7 @@ compare_t user_comparator(void * a, void * b) {
 
 void start_user_db(void) {
   return;
-    if (user_db != NULL) {
+  if (user_db != NULL) {
     printf("[user_db]: Already instantiated, not double-mallocing\n");
     return;
   }
@@ -98,7 +98,7 @@ void start_user_db(void) {
   printf("max users %d\n", user_db->max_users);
   user_db->user_index = mmap(NULL, user_db->max_users * sizeof(user_t) + sizeof(user_index_t), PROT_READ | PROT_WRITE, MAP_SHARED, user_db->user_index_fd, 0);
   user_db->user_data = mmap(NULL, user_db->max_users * sizeof(user_data_t), PROT_READ | PROT_WRITE, MAP_SHARED, user_db->user_data_fd, 0);
-
+/*
   if (!index_exists && !data_exists) {
     printf("making new user_index aa_tree\n");
     user_db->user_index->num_users = 0;
@@ -118,7 +118,7 @@ void start_user_db(void) {
     uintptr_t page_aligned_offset = (uintptr_t) user_db->user_index % PAGESIZE;
     uintptr_t page_aligned_addr = (uintptr_t) user_db->user_index - page_aligned_offset;
     msync((void *) page_aligned_addr, page_aligned_offset + sizeof(user_index_t), MS_ASYNC);
-  }
+  }*/
 }
 
 void end_user_db(void) {
@@ -132,18 +132,19 @@ void end_user_db(void) {
 }
 
 off_t get_user(char const * name) {
+  return 0;
   printf("[user_db]: get_user(%s)\n", name);
   aa_node_t * result = NULL;
   user_t user;
   strncpy(user.username, name, MAX_USERPASS_LEN);
   RWLOCK_RLOCK(&(user_db->rwlock_index));
-  if (aa_find(&(user_db->user_index->data), (void *) &user, &result)) {
-    RWLOCK_RUNLOCK(&(user_db->rwlock_index));
-    return ((user_t *) result->data)->offset;
-  } else {
-    RWLOCK_RUNLOCK(&(user_db->rwlock_index));
-    return -1;
-  }
+//   if (aa_find(&(user_db->user_index->data), (void *) &user, &result)) {
+//     RWLOCK_RUNLOCK(&(user_db->rwlock_index));
+//     return ((user_t *) result->data)->offset;
+//   } else {
+//     RWLOCK_RUNLOCK(&(user_db->rwlock_index));
+//     return -1;
+//   }
 }
 
 void update_user_data(off_t user_offset, object_t * object) {
@@ -170,6 +171,7 @@ void get_user_data(off_t user_offset, object_t * object) {
 }
 
 off_t create_user(char const * username, char const * password) {
+  return 0;
   if (user_db->num_users >= user_db->max_users) {
     user_db->max_users *= 2;
     RWLOCK_WLOCK(&(user_db->rwlock_data));
@@ -192,7 +194,7 @@ off_t create_user(char const * username, char const * password) {
     user_t * free_user = user_db->user_index->backing_nodes + user_db->user_index->num_users;
     strncpy(free_user->username, username, MAX_USERPASS_LEN);
     user_offset = free_user->offset = user_db->user_index->num_users;
-    aa_insert(&(user_db->user_index->data), (void *) free_user, &(free_user->node));
+//     aa_insert(&(user_db->user_index->data), (void *) free_user, &(free_user->node));
     void * new_user_addr = (void *) free_user;
 
     page_aligned_offset = (uintptr_t) new_user_addr % PAGESIZE;

--- a/users/user_db.c
+++ b/users/user_db.c
@@ -12,17 +12,11 @@
 #include "../world/world_server.h"
 
 typedef
-struct user_data_s {
-  char password[MAX_USERPASS_LEN];
-  object_t self;
-}
-user_data_t;
-
-typedef
 struct user_s {
-  char username[MAX_USERPASS_LEN];
-  off_t offset;
   aa_node_t node;
+  char username[MAX_USERPASS_LEN];
+  char password[MAX_USERPASS_LEN];
+  off_t data_off;
 }
 user_t;
 
@@ -30,13 +24,13 @@ typedef
 struct user_index_s {
   unsigned int num_users;
   off_t search_root;
-  user_t backing_nodes[];
+  user_t backing_nodes[1];
 }
 user_index_t;
 
 typedef
 struct user_db_s {
-  unsigned int num_users;
+  aa_tree_t tree;
   unsigned int max_users;
 
   pthread_rwlock_t rwlock_index;
@@ -51,6 +45,7 @@ struct user_db_s {
 user_db_t;
 
 user_db_t * user_db = NULL;
+static long PAGESIZE;
 
 compare_t user_comparator(void * a, void * b) {
   user_t * a_item = (user_t *) a;
@@ -59,11 +54,78 @@ compare_t user_comparator(void * a, void * b) {
   return cmp > 0 ? GT : cmp < 0 ? LT : EQ ;
 }
 
+unsigned int get_num_users() {
+  unsigned int ret;
+  RWLOCK_RLOCK(&(user_db->rwlock_index));
+  ret = user_db->user_index->num_users;
+  RWLOCK_RUNLOCK(&(user_db->rwlock_index));
+  return ret;
+}
+
+bool reallocate_databases(bool initial) {
+  fstore_t store = (fstore_t) {
+    .fst_flags = F_ALLOCATECONTIG,
+    .fst_posmode = F_PEOFPOSMODE,
+    .fst_offset = 0,
+    .fst_length = DB_INC_SIZE * sizeof(user_data_t),
+  };
+
+  printf("a\n");
+
+  RWLOCK_WLOCK(&(user_db->rwlock_index));
+  if (!initial && user_db->user_index->num_users < user_db->max_users) {
+    printf("[user_db]: databases online.\n\tNUM: %u\tMAX: %d\n", user_db->user_index->num_users, user_db->max_users);
+    RWLOCK_WUNLOCK(&(user_db->rwlock_index));
+    return true;
+  }
+
+  if (user_db->user_index) munmap(user_db->user_index, user_db->user_index->num_users * sizeof(user_t) + sizeof(user_index_t));
+  store.fst_flags = F_ALLOCATECONTIG;
+  store.fst_length = DB_INC_SIZE * sizeof(user_t);
+  store.fst_bytesalloc = 0;
+  if (-1 == fcntl(user_db->user_index_fd, F_PREALLOCATE, &store)) {
+    printf("[user_db: user_index.database]: Can't make more user room. Trying noncontiguous allocation.\n\tstrerror: %s\n", strerror(errno));
+    store.fst_flags = 0;
+    if (-1 == fcntl(user_db->user_index_fd, F_PREALLOCATE, &store)) {
+      printf("[user_db: user_index.database]: Can't make more user room. DATABASE FULL.\n\tstrerror: %s\n", strerror(errno));
+      return false;
+    }
+  }
+
+  unsigned int added_index_slots = store.fst_bytesalloc / sizeof(user_t);
+
+  RWLOCK_WLOCK(&(user_db->rwlock_data));
+  if (user_db->user_data) munmap(user_db->user_data, user_db->user_index->num_users * sizeof(user_data_t));
+  store.fst_flags = F_ALLOCATECONTIG;
+  if (-1 == fcntl(user_db->user_data_fd, F_PREALLOCATE, &store)) {
+    printf("[user_db: user_data.database]: Can't make more user room. Trying noncontiguous allocation.\n\tstrerror: %s\n", strerror(errno));
+    store.fst_flags = 0;
+    if (-1 == fcntl(user_db->user_data_fd, F_PREALLOCATE, &store)) {
+      printf("[user_db: user_data.database]: Can't make more user room. DATABASE FULL.\n\tstrerror: %s\n", strerror(errno));
+      return false;
+    }
+  }
+  unsigned int added_data_slots = store.fst_bytesalloc / sizeof(user_data_t);
+
+
+  user_db->max_users += fminl(added_data_slots, added_index_slots);
+
+  user_db->user_index = mmap(NULL, user_db->max_users * sizeof(user_t) + sizeof(user_index_t), PROT_READ | PROT_WRITE, MAP_SHARED, user_db->user_index_fd, 0);
+  rebase_aa_tree(&(user_db->tree), (void *) &(user_db->user_index->backing_nodes[0].node), (void *) user_db->user_index->backing_nodes);
+  user_db->user_data = mmap(NULL, user_db->max_users * sizeof(user_data_t), PROT_READ | PROT_WRITE, MAP_SHARED, user_db->user_data_fd, 0);
+  RWLOCK_WUNLOCK(&(user_db->rwlock_data));
+  RWLOCK_WUNLOCK(&(user_db->rwlock_index));
+
+  return true;
+}
+
 void start_user_db(void) {
   if (user_db != NULL) {
     printf("[user_db]: Already instantiated, not double-mallocing\n");
     return;
   }
+
+  PAGESIZE = sysconf(_SC_PAGESIZE);
 
   user_db = (user_db_t *) mmap(NULL, sizeof(user_db_t), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
   RWLOCK_INIT(&(user_db->rwlock_data));
@@ -81,39 +143,41 @@ void start_user_db(void) {
     user_db->user_data_fd = open("users/user_data.database", O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
     data_exists = true;
   }
-  printf("should have opened both database files by now\n");
+
   if (index_exists ^ data_exists) {
     printf("[user_db]: users database corrupted.\n\tuser_index.database file %s exist.\n\tuser_data.database file %s exist.\n\tServer Corrupted. Delete all database files or restore from backup.",
            index_exists ? "DOES" : "DOES NOT",
            data_exists ? "DOES" : "DOES NOT");
   }
+  unsigned int num_users_temp = 0;
   if (!index_exists && !data_exists) {
-    printf("num_users 0 since new db\n");
-    user_db->num_users = 0;
+    printf("[user_db]: databases not found. creating new...\n");
   } else {
-    read(user_db->user_index_fd, &(user_db->num_users),  sizeof(unsigned int));
+    read(user_db->user_index_fd, &(num_users_temp),  sizeof(unsigned int));
   }
-  user_db->max_users = fmaxl(user_db->num_users * 2, MIN_DB_SIZE);
-  printf("max users %d\n", user_db->max_users);
-  user_db->user_index = mmap(NULL, user_db->max_users * sizeof(user_t) + sizeof(user_index_t), PROT_READ | PROT_WRITE, MAP_SHARED, user_db->user_index_fd, 0);
-  user_db->user_data = mmap(NULL, user_db->max_users * sizeof(user_data_t), PROT_READ | PROT_WRITE, MAP_SHARED, user_db->user_data_fd, 0);
+  user_db->max_users = fmaxl(num_users_temp + DB_INC_SIZE, MIN_DB_SIZE);
+
+  user_db->user_data = NULL;
+  user_db->user_index = NULL;
+  user_db->tree = create_aa_tree(NULL, sizeof(user_t), NULL, user_comparator);
+  if (!reallocate_databases(true))
+    return;
 
   if (!index_exists && !data_exists) {
-    printf("making new user_index aa_tree\n");
-    user_db->user_index->num_users = 0;
-    user_db->user_index->backing_nodes[0] = (user_t) {
-      .offset = 0,
-      .node = (aa_node_t) {
-        .left = 0,
-        .right = 0,
-        .data = NULL,
-        .level = 0,
-      },
-    };
-    user_db->user_index->search_root = 0;
-
-    printf("all done!\n");
-    const long PAGESIZE = sysconf(_SC_PAGESIZE);
+    printf("[user_db]: Creating header data within the user_index database\n");
+    RWLOCK_WLOCK(&(user_db->rwlock_index));
+      ftruncate(user_db->user_index_fd, sizeof(user_index_t));
+      user_db->user_index->num_users = 0;
+      user_db->user_index->backing_nodes[0] = (user_t) {
+        .data_off = 0,
+        .node = (aa_node_t) {
+          .left = 0,
+          .right = 0,
+          .level = 0,
+        },
+      };
+      user_db->user_index->search_root = 0;
+    RWLOCK_WUNLOCK(&(user_db->rwlock_index));
     uintptr_t page_aligned_offset = (uintptr_t) user_db->user_index % PAGESIZE;
     uintptr_t page_aligned_addr = (uintptr_t) user_db->user_index - page_aligned_offset;
     msync((void *) page_aligned_addr, page_aligned_offset + sizeof(user_index_t), MS_ASYNC);
@@ -123,6 +187,8 @@ void start_user_db(void) {
 void end_user_db(void) {
   RWLOCK_DESTROY(&(user_db->rwlock_data));
   RWLOCK_DESTROY(&(user_db->rwlock_index));
+  // ftruncate(user_db->user_index_fd, user_db->user_index->num_users * sizeof(user_t) + sizeof(user_index_t));
+  // ftruncate(user_db->user_data_fd, user_db->user_index->num_users * sizeof(user_data_t));
   munmap(user_db->user_index, user_db->max_users * sizeof(user_t) + sizeof(user_index_t));
   munmap(user_db->user_data, user_db->max_users * sizeof(user_data_t));
   munmap(user_db, sizeof(user_db_t));
@@ -130,104 +196,106 @@ void end_user_db(void) {
   close(user_db->user_data_fd);
 }
 
-off_t get_user(char const * name) {
-  printf("[user_db]: get_user(%s)\n", name);
-  aa_node_t * result = NULL;
+enum auth_fail_e {
+  WRONG_PASS = -2,
+  NO_USRNAME = -1,
+};
+
+off_t get_user(char const * name, char const * pass) {
+  user_t * result = NULL;
   user_t user;
   strncpy(user.username, name, MAX_USERPASS_LEN);
   RWLOCK_RLOCK(&(user_db->rwlock_index));
-  if (aa_find(user_comparator, &(user_db->user_index->backing_nodes[0].node), user_db->user_index->search_root, (void *) &user, &result, sizeof(user_t))) {
+  if (aa_find(&(user_db->tree), user_db->user_index->search_root, (void *) &user, (void *) &result)) {
+    if(!strncmp(result->password, pass, MAX_USERPASS_LEN)) {
+      off_t ret = result->data_off;
+      RWLOCK_RUNLOCK(&(user_db->rwlock_index));
+      return ret;
+    }
     RWLOCK_RUNLOCK(&(user_db->rwlock_index));
-    return ((user_t *) result->data)->offset;
-  } else {
-    RWLOCK_RUNLOCK(&(user_db->rwlock_index));
-    return -1;
+    return WRONG_PASS;
   }
+  RWLOCK_RUNLOCK(&(user_db->rwlock_index));
+  return NO_USRNAME;
 }
 
-void update_user_data(off_t user_offset, object_t * object) {
-  const long PAGESIZE = sysconf(_SC_PAGESIZE);
+void update_user_data(off_t user_offset, user_data_t * user_data) {
   RWLOCK_WLOCK(&(user_db->rwlock_data));
-    memcpy(&(user_db->user_data[user_offset].self), object, sizeof(object_t));
+    memcpy(user_db->user_data + user_offset, user_data, sizeof(user_data_t));
     uintptr_t page_aligned_offset = (uintptr_t) (user_db->user_data + user_offset) % PAGESIZE;
     uintptr_t page_aligned_addr = (uintptr_t) (user_db->user_data + user_offset) - page_aligned_offset;
     msync((void *) page_aligned_addr, page_aligned_offset + sizeof(user_data_t), MS_ASYNC);
   RWLOCK_WUNLOCK(&(user_db->rwlock_data));
 }
 
-void get_user_data(off_t user_offset, object_t * object) {
+user_data_t get_user_data(off_t user_offset) {
+  user_data_t user_data;
   RWLOCK_RLOCK(&(user_db->rwlock_data));
-    memcpy(object, &(user_db->user_data[user_offset].self), sizeof(object_t));
+    user_data = user_db->user_data[user_offset];
   RWLOCK_RUNLOCK(&(user_db->rwlock_data));
+  return user_data;
 }
 
 off_t create_user(char const * username, char const * password) {
-  if (user_db->num_users >= user_db->max_users) {
-    user_db->max_users *= 2;
-    RWLOCK_WLOCK(&(user_db->rwlock_data));
-      munmap(user_db->user_data, user_db->num_users * sizeof(user_data_t));
-      user_db->user_data = mmap(NULL, user_db->max_users * sizeof(user_data_t), PROT_READ | PROT_WRITE, MAP_SHARED, user_db->user_data_fd, 0);
-    RWLOCK_WUNLOCK(&(user_db->rwlock_data));
-
-    RWLOCK_WLOCK(&(user_db->rwlock_index));
-      munmap(user_db->user_index, user_db->num_users * sizeof(user_t) + sizeof(user_index_t));
-      user_db->user_index = mmap(NULL, user_db->max_users * sizeof(user_t) + sizeof(user_index_t), PROT_READ | PROT_WRITE, MAP_SHARED, user_db->user_index_fd, 0);
-    RWLOCK_WUNLOCK(&(user_db->rwlock_index));
-  }
-
-  off_t user_offset = -1;
+  off_t user_data_offset = -1;
   uintptr_t page_aligned_addr;
   uintptr_t page_aligned_offset;
-  const long PAGESIZE = sysconf(_SC_PAGESIZE);
+
+  if (!reallocate_databases(false)) {
+    return -1;
+  }
 
   RWLOCK_WLOCK(&(user_db->rwlock_index));
+    ftruncate(user_db->user_index_fd, ++(user_db->user_index->num_users) * sizeof(user_t) + sizeof(user_index_t));
     user_t * free_user = user_db->user_index->backing_nodes + user_db->user_index->num_users;
+    user_data_offset = user_db->user_index->num_users - 1;
+    free_user->data_off = user_data_offset;
     strncpy(free_user->username, username, MAX_USERPASS_LEN);
-    user_offset = free_user->offset = user_db->user_index->num_users;
-    aa_insert(user_comparator, &(user_db->user_index->backing_nodes[0].node), &(user_db->user_index->search_root), (void *) free_user, user_offset, sizeof(user_t));
-    void * new_user_addr = (void *) free_user;
+    strncpy(free_user->password, password, MAX_USERPASS_LEN);
 
-    page_aligned_offset = (uintptr_t) new_user_addr % PAGESIZE;
-    page_aligned_addr = (uintptr_t) new_user_addr - page_aligned_offset;
+    aa_insert(&(user_db->tree), &(user_db->user_index->search_root), user_db->user_index->num_users);
+
+    page_aligned_offset = (uintptr_t) free_user % PAGESIZE;
+    page_aligned_addr = (uintptr_t) free_user - page_aligned_offset;
     msync((void *) page_aligned_addr, page_aligned_offset + sizeof(user_t), MS_ASYNC);
 
-    user_db->user_index->num_users++;
+    page_aligned_offset = (uintptr_t) &(user_db->user_index) % PAGESIZE;
+    page_aligned_addr = (uintptr_t) &(user_db->user_index) - page_aligned_offset;
+    msync((void *) page_aligned_addr, page_aligned_offset + sizeof(user_index_t), MS_ASYNC);
 
-    page_aligned_offset = (uintptr_t) &(user_db->user_index->num_users) % PAGESIZE;
-    page_aligned_addr = (uintptr_t) &(user_db->user_index->num_users) - page_aligned_offset;
-    msync((void *) page_aligned_addr, page_aligned_offset + sizeof(user_db->user_index->num_users), MS_ASYNC);
+  RWLOCK_WLOCK(&(user_db->rwlock_data));
+    ftruncate(user_db->user_data_fd, user_db->user_index->num_users * sizeof(user_data_t));
+  RWLOCK_WUNLOCK(&(user_db->rwlock_data));
   RWLOCK_WUNLOCK(&(user_db->rwlock_index));
 
-
-  RWLOCK_WLOCK(&(user_db->rwlock_index));
-    memcpy(user_db->user_data[user_offset].password, password, MAX_USERPASS_LEN);
-  RWLOCK_WUNLOCK(&(user_db->rwlock_index));
-
-  object_t self = create_ship((SGVec3D_t) {
+  user_data_t user_data = (user_data_t) {
+    .origin = (SGVec3D_t) {
       .x = SGVec_Load_Const(CHUNK_SIZE / 2.),
       .y = SGVec_Load_Const(CHUNK_SIZE / 2.),
       .z = SGVec_Load_Const(CHUNK_SIZE / 2.)
     },
-    (chunk_coord_t) {0,0,0});
-  update_user_data(user_offset, &self);
+    .abs_coord = (chunk_coord_t) {0,0,0}
+  };
 
-  return user_offset;
+  update_user_data(user_data_offset, &user_data);
+
+  return user_data_offset;
 }
 
 
 off_t login(char const * username, char const * password) {
-  off_t user_offset = get_user(username);
-  printf("[user_db]: user_offset: %lld\n", user_offset);
-  if (user_offset == -1) {
-    return create_user(username, password);
-  } else {
-      RWLOCK_RLOCK(&(user_db->rwlock_data));
-      user_data_t * user_data = user_db->user_data + user_offset;
-      if (!strncmp(password, user_data->password, MAX_USERPASS_LEN)) {
-        RWLOCK_RUNLOCK(&(user_db->rwlock_data));
-        return user_offset;
-      }
-      RWLOCK_RUNLOCK(&(user_db->rwlock_data));
+  // aa_error_check(&(user_db->tree), user_db->user_index->search_root, user_db->max_users);
+  off_t user_offset = get_user(username, password);
+  switch (user_offset) {
+    case NO_USRNAME:
+      printf("[user_db]: LOGIN: <%s:%s> %s\n", username, password, "CREATE");
+      return create_user(username, password);
+
+    case WRONG_PASS:
+      printf("[user_db]: LOGIN: <%s:%s> %s\n", username, password, "WRONG PASS");
+      return -1;
+    default:
+      printf("[user_db]: LOGIN: <%s:%s> %s\n", username, password, "SUCCESS");
+      return user_offset;
   }
-  return -1;
 }

--- a/users/user_db.h
+++ b/users/user_db.h
@@ -3,14 +3,22 @@
 
 #include "../math/aa_tree.h"
 #include "../math/vector_3d.h"
-#include "../world/world_db.h"
+#include "../world/chunk.h"
 
 #define MIN_DB_SIZE MAX_CLIENTS
+#define DB_INC_SIZE MIN_DB_SIZE
 #define MAX_USERPASS_LEN 32
 
+typedef
+struct user_data_s {
+  SGVec3D_t origin;
+  chunk_coord_t abs_coord;
+}
+user_data_t;
+
 off_t login(char const * username, char const * password);
-void update_user_data(off_t user_offset, object_t * object);
-void get_user_data(off_t user_offset, object_t * object);
+void update_user_data(off_t user_offset, user_data_t * user_data);
+user_data_t get_user_data(off_t user_offset);
 
 void start_user_db(void);
 void end_user_db(void);

--- a/world/world_db.c
+++ b/world/world_db.c
@@ -51,7 +51,6 @@ void generate_chunk(chunk_coord_t abs_coord, chunk_t * chunk) {
   );
 
   chunk->lights[0] = chunk->objects + 1;
-  RWLOCK_INIT(&(chunk->rwlock));
 }
 
 compare_t cache_comparator(void * a, void * b) {
@@ -71,61 +70,39 @@ unsigned int encode_chunk_coord(chunk_coord_t abs_coord) {
 }
 
 chunk_t * gather_chunk(chunk_coord_t abs_coord) {
-//   printf("gather_chunk %u %u %u START\n", abs_coord.x, abs_coord.y, abs_coord.z);
+  chunk_t * ret_chunk;
+
   unsigned int encoded_id = encode_chunk_coord(abs_coord);
   cache_item_t dummy = (cache_item_t) {
-    .prev = NULL,
-    .next = NULL,
     .encoded_id = encoded_id
   };
-  aa_node_t * cache_node;
-  chunk_t * ret_chunk;
+
   MTX_LOCK(&(world_server->world_db.db_mtx));
   cache_item_t * item = world_server->world_db.tail;
-//   printf("gather_chunk %u %u %u AA_FIND START\n", abs_coord.x, abs_coord.y, abs_coord.z);
-  if (aa_find(cache_comparator, world_server->world_db.search_nodes, world_server->world_db.search_root, (void *) &dummy, &cache_node, sizeof(aa_node_t))) {
-//     printf("gather_chunk %u %u %u AA_FIND TRUE\n", abs_coord.x, abs_coord.y, abs_coord.z);
-    item = (cache_item_t *) cache_node->data;
-  } else {
-    printf("gather_chunk %u %u %u AA_FIND FALSE\n", abs_coord.x, abs_coord.y, abs_coord.z);
+  if (!aa_find(&(world_server->world_db.search_tree), world_server->world_db.search_root, (void *) &dummy, (void **) &item)) {
     if (item->instantiated) {
-      printf("gather_chunk %u %u %u AA_DELETE START\n", abs_coord.x, abs_coord.y, abs_coord.z);
-      aa_error_check(world_server->world_db.search_nodes, world_server->world_db.search_root, CACHE_LEN, sizeof(aa_node_t));
-      aa_delete(cache_comparator, world_server->world_db.search_nodes, &(world_server->world_db.search_root), (void *) item, sizeof(aa_node_t));
-      printf("gather_chunk %u %u %u AA_DELETE DONE\n", abs_coord.x, abs_coord.y, abs_coord.z);
+      aa_error_check(&(world_server->world_db.search_tree), world_server->world_db.search_root, CACHE_LEN);
+      aa_delete(&(world_server->world_db.search_tree), &(world_server->world_db.search_root), (void *) item);
     } else {
-      static int numitemsused = 0;
-      numitemsused++;
-      printf("cache utilization %f%%\n", (float) numitemsused / (float) CACHE_LEN);
+      // static int numitemsused = 0;
+      // numitemsused++;
+      // printf("cache utilization %f%%\n", (float) numitemsused / (float) CACHE_LEN);
       item->instantiated = true;
     }
     item->encoded_id = encoded_id;
-//     printf("gather_chunk %u %u %u AA_INSERT START\n", abs_coord.x, abs_coord.y, abs_coord.z);
-    aa_insert(cache_comparator, world_server->world_db.search_nodes, &(world_server->world_db.search_root), (void *) item, item->search_node, sizeof(aa_node_t));
-//     printf("gather_chunk %u %u %u AA_INSERT DONE\n", abs_coord.x, abs_coord.y, abs_coord.z);
     RWLOCK_WLOCK(&(item->chunk.rwlock));
-//         printf("gather_chunk %u %u %u WLOCK\n", abs_coord.x, abs_coord.y, abs_coord.z);
-
-    generate_chunk(abs_coord, &(item->chunk));
-//         printf("gather_chunk %u %u %u GENCHUNK DONE\n", abs_coord.x, abs_coord.y, abs_coord.z);
-
+      generate_chunk(abs_coord, &(item->chunk));
     RWLOCK_WUNLOCK(&(item->chunk.rwlock));
-//         printf("gather_chunk %u %u %u WUNLOCK DONE\n", abs_coord.x, abs_coord.y, abs_coord.z);
 
+    aa_insert(&(world_server->world_db.search_tree), &(world_server->world_db.search_root), item->off);
   }
 
   promote(item);
-//     printf("gather_chunk %u %u %u PROMOTe DONE\n", abs_coord.x, abs_coord.y, abs_coord.z);
-
   RWLOCK_RLOCK(&(item->chunk.rwlock));
-//       printf("gather_chunk %u %u %u RLOCK DONE\n", abs_coord.x, abs_coord.y, abs_coord.z);
-
   ret_chunk = &(item->chunk);
-//       printf("gather_chunk %u %u %u ret chunk DONE\n", abs_coord.x, abs_coord.y, abs_coord.z);
 
   MTX_UNLOCK(&(world_server->world_db.db_mtx));
 
-//   printf("gather_chunk %u %u %u DONE\n", abs_coord.x, abs_coord.y, abs_coord.z);
   return ret_chunk;
 }
 
@@ -146,60 +123,43 @@ void gather_chunks(chunk_t ** chunk_storage, chunk_coord_t abs_coord) {
 
 void start_world_db(world_db_t * world_db) {
   MTX_INIT(&(world_db->db_mtx));
-
-
-  world_db->head = world_db->backing_data;
   world_db->backing_data[0] = (cache_item_t) {
     .prev = NULL,
-    .chunk = (chunk_t) {
-      .objects = world_db->backing_data[0].objects,
-      .lights = world_db->backing_data[0].lights,
-      .num_objects = 0,
-      .num_lights = 0,
-    },
-    .next = world_db->backing_data + 1,
-    .search_node = 1,
-    .instantiated = false
-  };
-  RWLOCK_INIT(&(world_db->backing_data[0].chunk.rwlock));
+    .next = NULL,
+    .instantiated = false,
 
-  for(int i = 1; i < CACHE_LEN - 1; i++) {
+    .off = 0,
+    .node = (aa_node_t) {
+      .left = 0,
+      .right = 0,
+      .level = 0,
+    },
+  };
+
+  world_db->head = world_db->backing_data + 1;
+  for(int i = 1; i <= CACHE_LEN; i++) {
     world_db->backing_data[i] = (cache_item_t) {
       .prev = world_db->backing_data + i - 1,
+      .next = world_db->backing_data + i + 1,
+      .instantiated = false,
+      .off = i,
       .chunk = (chunk_t) {
-        .objects = world_db->backing_data[i].objects,
-        .lights = world_db->backing_data[i].lights,
+        .objects = world_db->objects[i - 1],
+        .lights = world_db->lights[i - 1],
         .num_objects = 0,
         .num_lights = 0
       },
-      .next = world_db->backing_data + i + 1,
-      .search_node = i + 1,
-      .instantiated = false
     };
     RWLOCK_INIT(&(world_db->backing_data[i].chunk.rwlock));
   }
+  world_db->backing_data[CACHE_LEN].next = NULL;
+  world_db->tail = world_db->backing_data + CACHE_LEN;
 
-  world_db->backing_data[CACHE_LEN - 1] = (cache_item_t) {
-    .prev = world_db->backing_data + CACHE_LEN - 2,
-    .chunk = (chunk_t) {
-      .objects = world_db->backing_data[CACHE_LEN - 1].objects,
-      .lights = world_db->backing_data[CACHE_LEN - 1].lights,
-      .num_objects = 0,
-      .num_lights = 0
-    },
-    .next = NULL,
-    .search_node = CACHE_LEN,
-    .instantiated = false
-  };
-  RWLOCK_INIT(&(world_db->backing_data[CACHE_LEN - 1].chunk.rwlock));
-  world_db->tail = world_db->backing_data + CACHE_LEN - 1;
-  world_db->search_nodes[0] = (aa_node_t) {
-    .left = 0,
-    .right = 0,
-    .data = NULL,
-    .level = 0
-  };
   world_db->search_root = 0;
+  world_db->search_tree = create_aa_tree(&(world_db->backing_data[0].node),
+                                         sizeof(cache_item_t),
+                                         &(world_db->backing_data[0]),
+                                         cache_comparator);
 }
 
 void end_world_db(world_db_t * world_db) {

--- a/world/world_db.h
+++ b/world/world_db.h
@@ -29,17 +29,15 @@ chunk_t;
 typedef
 struct cache_item_s {
   //db_mtx protected
+  aa_node_t node;
+
   struct cache_item_s * prev;
   struct cache_item_s * next;
-  off_t search_node;
-  unsigned int encoded_id;
   bool instantiated;
 
-  //db_cache_rwlock protected
-  pthread_rwlock_t db_cache_item_rwlock;
+  unsigned int encoded_id;
   chunk_t chunk;
-  object_t objects[MAX_OBJECTS + MAX_LIGHTS];
-  object_t * lights[MAX_LIGHTS];
+  off_t off;
 }
 cache_item_t;
 
@@ -50,12 +48,13 @@ struct world_db_s {
   //db_mtx protected
   cache_item_t * head;
   cache_item_t * tail;
-//   aa_tree_t search_tree;
+  aa_tree_t search_tree;
+  off_t search_root;
 
   //db_cache_rwlock protected
-  cache_item_t backing_data[CACHE_LEN];
-  aa_node_t search_nodes[CACHE_LEN + 1];
-  off_t search_root;
+  cache_item_t backing_data[CACHE_LEN + 1];
+  object_t objects[CACHE_LEN][MAX_OBJECTS + MAX_LIGHTS];
+  object_t * lights[CACHE_LEN][MAX_LIGHTS];
 }
 world_db_t;
 

--- a/world/world_db.h
+++ b/world/world_db.h
@@ -31,7 +31,7 @@ struct cache_item_s {
   //db_mtx protected
   struct cache_item_s * prev;
   struct cache_item_s * next;
-  aa_node_t search_node;
+  off_t search_node;
   unsigned int encoded_id;
   bool instantiated;
 
@@ -50,10 +50,12 @@ struct world_db_s {
   //db_mtx protected
   cache_item_t * head;
   cache_item_t * tail;
-  aa_tree_t search_tree;
+//   aa_tree_t search_tree;
 
   //db_cache_rwlock protected
   cache_item_t backing_data[CACHE_LEN];
+  aa_node_t search_nodes[CACHE_LEN + 1];
+  off_t search_root;
 }
 world_db_t;
 

--- a/world/world_server.c
+++ b/world/world_server.c
@@ -39,23 +39,25 @@ void start_world_server() {
 }
 
 void request_player(unsigned int id, off_t user_offset) {
-  printf("requesting player\n");
   MTX_LOCK(world_server->player_mtxs + id);
-
-  get_user_data(user_offset, world_server->players + id);
+  user_data_t user_data = get_user_data(user_offset);
+  load_ship(world_server->players + id, &user_data);
   MTX_UNLOCK(world_server->player_mtxs + id);
 
   MTX_LOCK(&(world_server->active_ids_mtx));
   PUSH_FAST_LIST(world_server->active_ids, id);
   MTX_UNLOCK(&(world_server->active_ids_mtx));
-
-  printf("player created\n");
 }
 
 void request_player_save(unsigned int id, off_t user_index) {
+  user_data_t user_data;
   MTX_LOCK(world_server->player_mtxs + id);
-  update_user_data(user_index, world_server->players + id);
+    user_data = (user_data_t) {
+      .origin = world_server->players[id].origin,
+      .abs_coord = world_server->players[id].ship.abs_coord,
+    };
   MTX_UNLOCK(world_server->player_mtxs + id);
+  update_user_data(user_index, &user_data);
 }
 
 void request_player_end(unsigned int id) {


### PR DESCRIPTION
aa_trees used to use pointers for left and right, which meant they couldn't be saved and remapped in new memory. The pointers would go stale. Now everything uses an integer offset, which works when cold.

Also, the user db launches with this pull. Saved games work for saving locations and users. Orientation is not saved. All databases aren't compatible between changes to the code for a while. converting databases between versions will have to be a standalone tool.